### PR TITLE
feat: add support of authSchema

### DIFF
--- a/src/classes/Repository.ts
+++ b/src/classes/Repository.ts
@@ -10,22 +10,33 @@ export interface Env {
   [key: string]: string;
 }
 
-export interface Endpoint{
-    path: string;
-    desc: string;
-    method?: string;
+export type AuthSchema =
+  | {
+      type: 'Bearer' | 'Basic';
+      header: 'Authorization';
+    }
+  | {
+      type: 'ApiKey';
+      header: 'X-Access-Token';
+    };
+
+export interface Endpoint {
+  path: string;
+  desc: string;
+  method?: string;
+  authSchema?: AuthSchema;
 }
 
-export interface Api{
+export interface Api {
   [endpoint: string]: Endpoint;
 }
 
-export interface Period{
+export interface Period {
   env: Env;
   api: Api;
 }
 
-export interface Data{
+export interface Data {
   [version: string]: Period;
 }
 
@@ -57,7 +68,11 @@ export class Repository {
 
   private checkout(workspace: string) {
     const file = path.resolve(this.cache, workspace, '.endpoints.json')
-    const mainBranch = execSync(`cd ${this.cache}; git rev-parse --abbrev-ref origin/HEAD`).toString().trim()
+    const mainBranch = execSync(
+      `cd ${this.cache}; git rev-parse --abbrev-ref origin/HEAD`,
+    )
+    .toString()
+    .trim()
     execSync(`cd ${this.cache}; git checkout ${mainBranch} -- ${file}`)
     return JSON.parse(fs.readFileSync(file).toString())
   }

--- a/src/templates/functions/endpoint.ts
+++ b/src/templates/functions/endpoint.ts
@@ -103,5 +103,6 @@ export const endpoint = (name: string, e: Endpoint) => {
       return __queries ? \`\${__path}?\${__queries}\` : __path;
     };
   `,
-  e.method ? `${name}.method='${e.method}' as const;` : null].filter(Boolean).join('\n')
+  e.method ? `${name}.method='${e.method}' as const;` : null,
+  e.authSchema ? `${name}.authSchema=${JSON.stringify(e.authSchema)} as const;` : null].filter(Boolean).join('\n')
 }


### PR DESCRIPTION
Closes #73 

authSchemaをどう扱うかは、利用側に託すのが自然だと思うので、とりあえず渡されたauthSchemaをそのまま返しているだけです。


利用想定
```tsx
useMes(someEndpoint, { body : {}})

useMes(someEndpointWithAuthSchema, token, { body: {} }) 
```