### PR TITLE
fix: improve repository clone performance

### DIFF
--- a/src/executers/endpoint/createEndpointFiles.ts
+++ b/src/executers/endpoint/createEndpointFiles.ts
@@ -17,7 +17,7 @@ export async function createEndpointFiles(
   environmentIdentifier: string,
   output: string,
 ): Promise<Service> {
-  const clonedRepositoryPath = cloneRepository(service.repository);
+  const clonedRepositoryPath = cloneRepository(service.repository, service.workspaces ? service.workspaces[0] : undefined);
   const commitHash = service.version ?? getHeadCommitHash(clonedRepositoryPath);
   const branchName = service.branch ?? detectMainBranch(clonedRepositoryPath);
   const workspace = service.workspaces ? service.workspaces[0] : undefined;

--- a/src/executers/repository/cloneRepository.test.ts
+++ b/src/executers/repository/cloneRepository.test.ts
@@ -1,20 +1,45 @@
 import { describe, it, expect, vi } from "vitest";
 import { cloneRepository } from "./cloneRepository";
+import fs from "fs";
+import path from "path";
 
 describe("cloneRepository", () => {
+  const createTempDir = () => {
+    const tempDir = path.join("node_modules/.endpoints-tmp", `${new Date().getTime()}`);
+    fs.mkdirSync(tempDir, { recursive: true });
+    return tempDir;
+  };
+
+  const removeTempDir = (dir: string) => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  };
+
   it("should clone the repository and return the cache path", () => {
     const sshPath = "https://github.com/matsuri-tech/endpoints-sdk-cli.git";
     vi.useFakeTimers();
-    const cachePath = `node_modules/.endpoints-tmp/${new Date().getTime()}`;
+    const cachePath = createTempDir();
 
-    const result = cloneRepository(sshPath);
+    const result = cloneRepository(sshPath, undefined);
 
     expect(result).toBe(cachePath);
+    removeTempDir(cachePath);
   });
 
   it("should throw an error if the repository is not found", () => {
     const wrongSshPath = "--quiet wrong-github.com";
 
-    expect(() => cloneRepository(wrongSshPath)).toThrowError();
+    expect(() => cloneRepository(wrongSshPath, undefined)).toThrowError();
+  });
+
+  it("should clone the repository with workspace and return the cache path", () => {
+    const sshPath = "https://github.com/matsuri-tech/endpoints-sdk-cli.git";
+    const workspace = "example";
+    vi.useFakeTimers();
+    const cachePath = createTempDir();
+
+    const result = cloneRepository(sshPath, workspace);
+
+    expect(result).toBe(cachePath);
+    removeTempDir(cachePath);
   });
 });

--- a/src/executers/repository/cloneRepository.ts
+++ b/src/executers/repository/cloneRepository.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "child_process";
 
-export function cloneRepository(sshPath: string): string {
+export function cloneRepository(sshPath: string, workspace: string | undefined): string {
   console.info(`git clone ${sshPath}...`);
   const cache = `node_modules/.endpoints-tmp/${new Date().getTime()}`;
   const result = spawnSync("git", [
@@ -16,6 +16,11 @@ export function cloneRepository(sshPath: string): string {
   if (error) {
     throw new Error(`Failed to clone repository: ${error}`);
   }
+
+  spawnSync("git", ["sparse-checkout", "init", "--cone"], { cwd: cache });
+
+  const endpointsFile = workspace !== null ? `${workspace}/.endpoints.json` : ".endpoints.json";
+  spawnSync("git", ["sparse-checkout", "set", endpointsFile], { cwd: cache });
 
   console.info(`git clone ${sshPath} done!`);
   return cache;

--- a/src/executers/repository/getRepositoryData.ts
+++ b/src/executers/repository/getRepositoryData.ts
@@ -9,14 +9,10 @@ export async function getRepositoryData(
   workspace?: string,
   commitHash?: string,
 ): Promise<EndpointSetting> {
-  const endpointsFile =
-    workspace !== undefined
-      ? `./${workspace}/.endpoints.json`
-      : "./.endpoints.json";
-
+  
   const checkoutResult = spawnSync(
     "git",
-    ["checkout", branchName, "--", endpointsFile],
+    ["checkout", branchName],
     { cwd: repositoryPath },
   );
 


### PR DESCRIPTION
Closes #112


## Memo

- sparse checkoutで必要最低限のファイルのみをcloneするようにしました。
- まだパフォーマンスを改善する余地はあります。
　- 例：addコマンドでは、まずデフォルトブランチを特定する必要があるので今回はやっていないですが、installコマンドやupdateコマンドが利用される場合は、ブランチが明らかなので、ブランチ切り替え分を省けます。