### PR TITLE
chore: リリースノートを作成するGitHub Actionsワークフローを追加

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,74 @@
+name: Create Release Note
+
+on:
+  schedule:
+    - cron: "0 5 * * 2"
+  workflow_dispatch:
+
+jobs:
+  check-commits:
+    runs-on: ubuntu-latest
+    outputs:
+      has_new_commits: ${{ steps.check.outputs.has_new_commits }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for new commits
+        id: check
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          COMMIT_COUNT=$(git rev-list $LAST_TAG..HEAD --count)
+          echo "has_new_commits=$([ $COMMIT_COUNT -gt 0 ] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
+          echo "No new commits since last tag ($LAST_TAG). Skipping release PR creation."
+
+  create-release-pr:
+    needs: check-commits
+    if: needs.check-commits.outputs.has_new_commits == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version bump type
+        id: version_bump
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          COMMITS=$(git log $LAST_TAG..HEAD --pretty=format:"%s")
+
+          VERSION_BUMP="patch"
+
+          while IFS= read -r commit; do
+            if [[ $commit =~ ^(feat!|.*BREAKING CHANGE:) ]]; then
+              VERSION_BUMP="major"
+              break
+            elif [[ $commit =~ ^feat: ]] && [ "$VERSION_BUMP" != "major" ]; then
+              VERSION_BUMP="minor"
+            fi
+          done <<< "$COMMITS"
+
+          echo "version_bump=$VERSION_BUMP" >> $GITHUB_OUTPUT
+          echo "Version bump type: $VERSION_BUMP"
+
+      - name: Bump version
+        id: bump_version
+        run: |
+          pnpm version ${{ steps.version_bump.outputs.version_bump }} --no-git-tag-version
+
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "Bumped version to: $NEW_VERSION"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.REPO_ONLY_GITHUB_TOKEN }}
+          commit-message: "chore: bump version to v${{ steps.bump_version.outputs.new_version }}"
+          title: "Release Note: v${{ steps.bump_version.outputs.new_version }}"
+          branch: release/v${{ steps.bump_version.outputs.new_version }}
+          base: master
+          reviewers: hrdtbs
+          labels: release
+          delete-branch: true


### PR DESCRIPTION
## Why

Closes #123 

## Memo

パブリックリポジトリなのでorganizationのトークンが利用できませんが、このリポジトリにこのリポジトリのみの権限を持ったトークンを別途発行して対応しました。