### PR TITLE
fix: suppress json-schema-to-typescript banner comment (#106)

### DIFF
--- a/src/templates/functions/endpoint/createEndpoint.test.ts
+++ b/src/templates/functions/endpoint/createEndpoint.test.ts
@@ -95,6 +95,32 @@ export const health_check = () => {
 health_check.method = "GET" as const;`);
 });
 
+test("request/responseスキーマが指定されてもjson-schema-to-typescriptのバナーコメントは出力されない", async () => {
+  const endpoint = {
+    method: "POST",
+    path: "users",
+    desc: "Create user",
+    request: {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+      required: ["name"],
+    },
+    response: {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+      },
+      required: ["id"],
+    },
+  };
+  const result = await createEndpoint("create_user", endpoint);
+  expect(result).not.toContain("json-schema-to-typescript");
+  expect(result).not.toContain("DO NOT MODIFY");
+  expect(result).not.toContain("eslint-disable");
+});
+
 test("パスが空文字の場合はルートパスが生成される", async () => {
   const endpoint = {
     method: "GET",

--- a/src/templates/functions/endpoint/createEndpoint.ts
+++ b/src/templates/functions/endpoint/createEndpoint.ts
@@ -65,10 +65,10 @@ export async function createEndpoint(
   );
 
   const request = endpoint.request
-    ? await compile(endpoint.request, `${name}Request`)
+    ? await compile(endpoint.request, `${name}Request`, { bannerComment: "" })
     : undefined;
   const response = endpoint.response
-    ? await compile(endpoint.response, `${name}Response`)
+    ? await compile(endpoint.response, `${name}Response`, { bannerComment: "" })
     : undefined;
 
   const func = `


### PR DESCRIPTION
## Summary
- `compile()` (json-schema-to-typescript) に `bannerComment: ""` を渡し、生成される request / response 型の先頭に出力される `eslint-disable` / "DO NOT MODIFY" の定型コメントを抑制。
- 該当の挙動を確認する回帰テストを追加。

Closes #106

## Test plan
- [x] `pnpm test --run src/templates/functions/endpoint/createEndpoint.test.ts` (6/6 passed)
- [x] `pnpm typecheck`
- [x] `pnpm lint` (prettier OK / eslint clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)