### PR TITLE
chore: align minimumReleaseAge between pnpm and renovate

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
+# pnpm v11 default, declared explicitly to stay in sync with renovate.json's minimumReleaseAge
+minimumReleaseAge: 1440
 allowBuilds:
   esbuild: true

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     "helpers:pinGitHubActionDigestsToSemver"
   ],
   "reviewers": ["hrdtbs"],
+  "minimumReleaseAge": "1 day",
   "packageRules": [
     {
       "matchDepTypes": ["action"],


### PR DESCRIPTION
## What

- `pnpm-workspace.yaml`: declare `minimumReleaseAge: 1440` (minutes / 24h) explicitly
- `renovate.json`: add the matching `"minimumReleaseAge": "1 day"`

## Why

pnpm and Renovate each have a `minimumReleaseAge` setting on different layers:

| | When it applies | Effect |
|---|---|---|
| Renovate | before creating a PR | won't open an update PR until the version is N old |
| pnpm (v11+) | at dependency resolution | won't resolve versions newer than N |

pnpm v11 turned this on by default at **1440 minutes (24h)**, but it was implicit and depends on the pnpm version in use. If Renovate has no equivalent gate, it can write a just-published version into `package.json` and then fail to update the lockfile because pnpm refuses to resolve it — producing manifest/lockfile mismatches and `--frozen-lockfile` CI failures.

This change makes the pnpm default explicit (so it no longer depends on the runtime pnpm version) and sets Renovate to the same 24h gate, so the "PR gate" and the "resolution gate" stay in sync.

## Notes for reviewer

- `1440` minutes (pnpm) == `"1 day"` (Renovate) — intentionally equal.
- No code/behavior change beyond dependency update timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)